### PR TITLE
Fix `MagickWand::write_image_pixels_to` lifetime anntation

### DIFF
--- a/graphicsmagick-sys/build.rs
+++ b/graphicsmagick-sys/build.rs
@@ -97,7 +97,7 @@ fn main() -> anyhow::Result<()> {
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     let binding_path = out_path.join("bindings.rs");
     bindings
-        .write_to_file(&binding_path)
+        .write_to_file(binding_path)
         .context("Couldn't write bindings!")?;
 
     Ok(())

--- a/graphicsmagick/src/utils/init.rs
+++ b/graphicsmagick/src/utils/init.rs
@@ -1,21 +1,12 @@
 use graphicsmagick_sys::InitializeMagick;
-use std::{ptr::null, sync::Once, thread};
+use std::{ptr::null, sync::Once};
 
 static HAS_INITIALIZED: Once = Once::new();
 
 /// Wrapper of `graphicsmagick_sys::InitializeMagick`, call it before any `graphicsmagick` action.
-/// Must be call in the main thread.
 pub fn initialize() {
-    HAS_INITIALIZED.call_once(|| {
-        assert_eq!(
-            thread::current().name(),
-            Some("main"),
-            "You have to call `graphicsmagick::initialize` in main thread"
-        );
-
-        unsafe {
-            InitializeMagick(null());
-        }
+    HAS_INITIALIZED.call_once(|| unsafe {
+        InitializeMagick(null());
     });
 }
 

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -1457,7 +1457,7 @@ impl MagickWand<'_> {
         x_offset: c_long,
         y_offset: c_long,
         input: MagickWandExportSlice<'a, T>,
-    ) -> crate::Result<&mut [T]> {
+    ) -> crate::Result<&'a mut [T]> {
         let len = input.len();
         let map = input.map;
         let storage = T::STORAGE_TYPE;

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -4104,7 +4104,7 @@ mod tests {
 
     #[test]
     fn test_magick_wand_read_image_blob() {
-        let mut file = File::open(&logo_path()).unwrap();
+        let mut file = File::open(logo_path()).unwrap();
         let mut content = Vec::new();
         file.read_to_end(&mut content).unwrap();
 


### PR DESCRIPTION
The returned slice shall have the same lifetime as
`MagickWandExportSlice`.

Also fix clippy warnings.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>