### PR TITLE
Refactor rust.yml jobs: split into three

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,8 +70,8 @@ jobs:
       - name: Doc
         run: cargo +${{ env.NIGHTLY }} rustdoc --manifest-path graphicsmagick/Cargo.toml --features v1_3_38 -- --cfg docsrs
 
-  all:
-    name: All
+  test:
+    name: Run test
 
     strategy:
       fail-fast: false
@@ -134,15 +134,18 @@ jobs:
 
       - name: Rustup
         run: |
-          rustup show
-          rustup component add rustfmt clippy
-          rustup toolchain install ${{ env.NIGHTLY }} --allow-downgrade -c rustfmt clippy --no-self-update
+          rustup toolchain install ${{ env.NIGHTLY }} --allow-downgrade --no-self-update
 
       - name: Generate Cargo.lock
         run: cargo +${{ env.NIGHTLY }} -Z minimal-versions update
 
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
       - uses: Swatinem/rust-cache@v2
 
-
-      - name: Docf
-        run: cargo +${{ env.NIGHTLY }} rustdoc --manifest-path graphicsmagick/Cargo.toml --features ${{ matrix.flag.feature }} -- --cfg docsrs
+      - name: Test
+        run: |
+          cargo nextest --features ${{ matrix.flag.feature }}
+          cargo test --doc --features ${{ matrix.flag.feature }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,59 @@ env:
   NIGHTLY: nightly-2023-03-15
 
 jobs:
+  fmt-and-clippy:
+    name: formatting and clippy
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/install-sys-deps
+        with:
+          version: GraphicsMagick-1_3_20
+
+      - name: Rustup
+        run: |
+          rustup component add clippy
+          rustup toolchain install $NIGHTLY --allow-downgrade -c rustfmt --no-self-update
+
+      - name: Generate Cargo.lock
+        run: cargo +${{ env.NIGHTLY }} -Z minimal-versions update
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Fmt
+        run: cargo +${{ env.NIGHTLY }} fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --no-deps
+
+  doc:
+    name: Build doc
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/install-sys-deps
+        with:
+          version: GraphicsMagick-1_3_38
+
+      - name: Rustup
+        run: |
+          rustup toolchain install ${{ env.NIGHTLY }} --allow-downgrade --no-self-update
+
+      - name: Generate Cargo.lock
+        run: cargo +${{ env.NIGHTLY }} -Z minimal-versions update
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Doc
+        run: cargo +${{ env.NIGHTLY }} rustdoc --manifest-path graphicsmagick/Cargo.toml --features v1_3_38 -- --cfg docsrs
+
   all:
     name: All
 
@@ -25,7 +78,7 @@ jobs:
 
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-latest
         # - macos-latest
         # - windows-latest
 
@@ -90,14 +143,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Fmt
-        run: cargo +${{ env.NIGHTLY }} fmt --all -- --check
 
-      - name: Clippy
-        run: cargo clippy --verbose
-
-      - name: Test
-        run: cargo test --verbose --features ${{ matrix.flag.feature }} -- --test-threads=1 --nocapture
-
-      - name: Doc
+      - name: Docf
         run: cargo +${{ env.NIGHTLY }} rustdoc --manifest-path graphicsmagick/Cargo.toml --features ${{ matrix.flag.feature }} -- --cfg docsrs

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -147,5 +147,5 @@ jobs:
 
       - name: Test
         run: |
-          cargo nextest --features ${{ matrix.flag.feature }}
+          cargo nextest run --features ${{ matrix.flag.feature }}
           cargo test --doc --features ${{ matrix.flag.feature }}

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -4813,6 +4813,7 @@ mod tests {
 
     #[test]
     fn test_magick_wand_get_resource_limit() {
+        initialize();
         MagickWand::get_resource_limit(ResourceType::UndefinedResource);
     }
 

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -5052,11 +5052,13 @@ mod tests {
 
     #[test]
     fn test_magick_wand_query_fonts() {
+        initialize();
         MagickWand::query_fonts("").unwrap();
     }
 
     #[test]
     fn test_magick_wand_query_formats() {
+        initialize();
         MagickWand::query_formats("").unwrap();
     }
 

--- a/graphicsmagick/src/wand/magick.rs
+++ b/graphicsmagick/src/wand/magick.rs
@@ -5416,6 +5416,7 @@ mod tests {
 
     #[test]
     fn test_magick_wand_set_resource_limit() {
+        initialize();
         MagickWand::set_resource_limit(ResourceType::UndefinedResource, 0);
     }
 


### PR DESCRIPTION
To make sure that nightly and stable builds do not invalidate the cache.