### PR TITLE
CI: Fix install-sys-deps

### DIFF
--- a/.github/actions/install-sys-deps/action.yml
+++ b/.github/actions/install-sys-deps/action.yml
@@ -14,14 +14,18 @@ runs:
         path: /home/runner/.local/
         key: v5-${{ runner.os }}-graphicsmagick-${{ inputs.version }}
 
-    - name: Build and Install GraphicsMagick
-      if: steps.cache-graphicsmagick.outputs.cache-hit != 'true'
-      shell: bash
+    - name: Install dependencies
       run: |
         set -euxo pipefail
         sudo sed -i '/^#\sdeb-src /s/^#//' "/etc/apt/sources.list"
         sudo apt-get update
         sudo apt-get build-dep -y graphicsmagick
+  
+    - name: Build and Install GraphicsMagick
+      if: steps.cache-graphicsmagick.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euxo pipefail
         sudo apt-get install -y llvm-dev libclang-dev clang mercurial libfreetype6-dev
         hg clone http://hg.code.sf.net/p/graphicsmagick/code /tmp/graphicsmagick
         cd /tmp/graphicsmagick

--- a/.github/actions/install-sys-deps/action.yml
+++ b/.github/actions/install-sys-deps/action.yml
@@ -13,11 +13,11 @@ runs:
       with:
         path: |
           /usr/local/bin
-          /usr/local/**/GraphicsMagick*/**
+          /usr/local/**/GraphicsMagick*/config
           /usr/local/include/GraphicsMagick
           /usr/local/lib/libGraphicsMagickWand*
           /usr/local/lib/pkgconfig/GraphicsMagick*
-        key: v3-${{ runner.os }}-graphicsmagick-${{ inputs.version }}
+        key: v4-${{ runner.os }}-graphicsmagick-${{ inputs.version }}
 
     - name: Build and Install GraphicsMagick
       if: steps.cache-graphicsmagick.outputs.cache-hit != 'true'

--- a/.github/actions/install-sys-deps/action.yml
+++ b/.github/actions/install-sys-deps/action.yml
@@ -15,6 +15,7 @@ runs:
         key: v5-${{ runner.os }}-graphicsmagick-${{ inputs.version }}
 
     - name: Install dependencies
+      shell: bash
       run: |
         set -euxo pipefail
         sudo sed -i '/^#\sdeb-src /s/^#//' "/etc/apt/sources.list"

--- a/.github/actions/install-sys-deps/action.yml
+++ b/.github/actions/install-sys-deps/action.yml
@@ -13,9 +13,11 @@ runs:
       with:
         path: |
           /usr/local/bin
+          /usr/local/**/GraphicsMagick*/**
           /usr/local/include/GraphicsMagick
-          /usr/local/lib
-        key: v2-${{ runner.os }}-graphicsmagick-${{ inputs.version }}
+          /usr/local/lib/libGraphicsMagickWand*
+          /usr/local/lib/pkgconfig/GraphicsMagick*
+        key: v3-${{ runner.os }}-graphicsmagick-${{ inputs.version }}
 
     - name: Build and Install GraphicsMagick
       if: steps.cache-graphicsmagick.outputs.cache-hit != 'true'

--- a/.github/actions/install-sys-deps/action.yml
+++ b/.github/actions/install-sys-deps/action.yml
@@ -11,8 +11,11 @@ runs:
       id: cache-graphicsmagick
       uses: actions/cache@v4
       with:
-        path: /usr/local
-        key: v1-${{ runner.os }}-graphicsmagick-${{ inputs.version }}
+        path: |
+          /usr/local/bin
+          /usr/local/include/GraphicsMagick
+          /usr/local/lib
+        key: v2-${{ runner.os }}-graphicsmagick-${{ inputs.version }}
 
     - name: Build and Install GraphicsMagick
       if: steps.cache-graphicsmagick.outputs.cache-hit != 'true'

--- a/.github/actions/install-sys-deps/action.yml
+++ b/.github/actions/install-sys-deps/action.yml
@@ -7,43 +7,32 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: System info
-      run: cat /etc/apt/sources.list
-      shell: bash
-
-    - name: Dependencies
-      shell: bash
-      run: |
-        sudo sed -i '/^#\sdeb-src /s/^#//' "/etc/apt/sources.list"
-        sudo apt-get update
-        sudo apt-get build-dep -y graphicsmagick
-        sudo apt-get install -y llvm-dev libclang-dev clang mercurial libfreetype6-dev
-
     - name: Configure caching for graphicsmagick
       id: cache-graphicsmagick
       uses: actions/cache@v4
       with:
-        path: /tmp/graphicsmagick
-        key: ${{ runner.os }}-graphicsmagick-${{ inputs.version }}
+        path: /usr/local
+        key: v1-${{ runner.os }}-graphicsmagick-${{ inputs.version }}
 
-    - name: Build GraphicsMagick
+    - name: Build and Install GraphicsMagick
       if: steps.cache-graphicsmagick.outputs.cache-hit != 'true'
       shell: bash
       run: |
+        set -euxo pipefail
+        sudo sed -i '/^#\sdeb-src /s/^#//' "/etc/apt/sources.list"
+        sudo apt-get update
+        sudo apt-get build-dep -y graphicsmagick
+        sudo apt-get install -y llvm-dev libclang-dev clang mercurial libfreetype6-dev
         hg clone http://hg.code.sf.net/p/graphicsmagick/code /tmp/graphicsmagick
         cd /tmp/graphicsmagick
         hg update -r ${{ inputs.version }}
         ./configure
-        make -j $(nproc)
-
-    - name: Install GraphicsMagick
-      shell: bash
-      working-directory: /tmp/graphicsmagick
-      run: sudo make install -j $(nproc)
+        sudo make install -j $(nproc)
 
     - name: Info
       shell: bash
       run: |
+        ldconfig -n /usr/local/lib
         gm version
         echo
         GraphicsMagick-config --cppflags --ldflags --libs

--- a/.github/actions/install-sys-deps/action.yml
+++ b/.github/actions/install-sys-deps/action.yml
@@ -11,7 +11,7 @@ runs:
       id: cache-graphicsmagick
       uses: actions/cache@v4
       with:
-        path: ${{ env.HOME }}/.local
+        path: /home/runner/.local/
         key: v5-${{ runner.os }}-graphicsmagick-${{ inputs.version }}
 
     - name: Build and Install GraphicsMagick

--- a/.github/actions/install-sys-deps/action.yml
+++ b/.github/actions/install-sys-deps/action.yml
@@ -11,13 +11,8 @@ runs:
       id: cache-graphicsmagick
       uses: actions/cache@v4
       with:
-        path: |
-          /usr/local/bin
-          /usr/local/**/GraphicsMagick*/config
-          /usr/local/include/GraphicsMagick
-          /usr/local/lib/libGraphicsMagickWand*
-          /usr/local/lib/pkgconfig/GraphicsMagick*
-        key: v4-${{ runner.os }}-graphicsmagick-${{ inputs.version }}
+        path: ${{ env.HOME }}/.local
+        key: v5-${{ runner.os }}-graphicsmagick-${{ inputs.version }}
 
     - name: Build and Install GraphicsMagick
       if: steps.cache-graphicsmagick.outputs.cache-hit != 'true'
@@ -31,13 +26,18 @@ runs:
         hg clone http://hg.code.sf.net/p/graphicsmagick/code /tmp/graphicsmagick
         cd /tmp/graphicsmagick
         hg update -r ${{ inputs.version }}
-        ./configure
-        sudo make install -j $(nproc)
+        ./configure --prefix="$HOME/.local"
+        make install -j $(nproc)
+
+    - name: Add $HOME/.local to PATH
+      shell: bash
+      run: |
+        echo "$HOME/.local" >> "$GITHUB_PATH"
+        ldconfig -n "$HOME/.local/lib"
 
     - name: Info
       shell: bash
       run: |
-        ldconfig -n /usr/local/lib
         gm version
         echo
         GraphicsMagick-config --cppflags --ldflags --libs


### PR DESCRIPTION
Cache installed files /usr/local to make sure no rebuild happens.

It would also be more efficient as build artifacts aren't cached, and dependencies are only installed if no cache is available.